### PR TITLE
Config flow option to not add entities for gw #31

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -497,7 +497,7 @@ class LocaltuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Add a checkbox that allows bailing out from config flow iff at least one
         # entity has been added
         schema = PICK_ENTITY_SCHEMA
-        if self.platform is not None:
+        if self.platform is not None or self.basic_info[CONF_IS_GATEWAY]:
             schema = schema.extend(
                 {vol.Required(NO_ADDITIONAL_PLATFORMS, default=True): bool}
             )


### PR DESCRIPTION
Added option in Config flow to skips adding entities for Gateway devices
https://github.com/leeyuentuen/localtuya/issues/31