### PR TITLE
3.7.0-Revert_heartbeat_fix_payload_dict

### DIFF
--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -261,12 +261,24 @@ PAYLOAD_DICT = {
             COMMAND_OVERRIDE: CONTROL_NEW,  # Uses CONTROL_NEW command
             COMMAND: {"protocol": 5, "t": "int", "data": ""},
         },
-        DP_QUERY: {COMMAND_OVERRIDE: DP_QUERY_NEW},
+        DP_QUERY: {
+            COMMAND_OVERRIDE: DP_QUERY_NEW,
+            COMMAND: {PARAMETER_GW_ID: "", PARAMETER_DEV_ID: "", PARAMETER_UID: "" },
+        },
         DP_QUERY_NEW: {
-            COMMAND: {PARAMETER_CID: ""},
+            COMMAND: {PARAMETER_DEV_ID: "", PARAMETER_UID: "", PARAMETER_T: ""}
         },
         HEART_BEAT: {
-            COMMAND: {}
+            COMMAND: {PARAMETER_GW_ID: "", PARAMETER_DEV_ID: ""}
+        },
+        CONTROL_NEW: {
+            COMMAND: {PARAMETER_DEV_ID: "", PARAMETER_UID: "", PARAMETER_T: "", PARAMETER_CID: ""}
+        },
+        STATUS: {  # Get Status from Device
+           COMMAND: {PARAMETER_GW_ID: "", PARAMETER_DEV_ID: ""},
+        },
+        UPDATEDPS: {
+            COMMAND: {PARAMETER_DP_ID: [18, 19, 20]},
         },
     },
 }

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -714,7 +714,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
         self.transport = transport
         self.on_connected.set_result(True)
-        self.heartbeater = self.loop.create_task(heartbeat_loop())
+        # self.heartbeater = self.loop.create_task(heartbeat_loop())
 
     def data_received(self, data):
         """Received data from device."""

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -1238,11 +1238,11 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
         json_data = command_override = None
         if self.dev_type in payload_dict and command in payload_dict[self.dev_type]:
-            if command in payload_dict[self.dev_type]:
-                json_data = payload_dict[self.dev_type][command]
-            if command_override in payload_dict[self.dev_type][command]:
+            if COMMAND in payload_dict[self.dev_type][command]:
+                json_data = payload_dict[self.dev_type][command][COMMAND]
+            if COMMAND_OVERRIDE in payload_dict[self.dev_type][command]:
                 command_override = payload_dict[self.dev_type][command][
-                    command_override
+                    COMMAND_OVERRIDE
                 ]
 
         if self.dev_type != DEV_TYPE_0A:
@@ -1250,16 +1250,16 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 json_data is None
                 and self.dev_type in payload_dict
                 and command in payload_dict[self.dev_type]
-                and command in payload_dict[self.dev_type][command]
+                and COMMAND in payload_dict[self.dev_type][command]
             ):
-                json_data = payload_dict[self.dev_type][command][command]
+                json_data = payload_dict[self.dev_type][command][COMMAND]
             if (
                 command_override is None
                 and self.dev_type in payload_dict
                 and command in payload_dict[self.dev_type]
-                and command_override in payload_dict[self.dev_type][command]
+                and COMMAND_OVERRIDE in payload_dict[self.dev_type][command]
             ):
-                command_override = payload_dict[self.dev_type][command][command_override]
+                command_override = payload_dict[self.dev_type][command][COMMAND_OVERRIDE]
 
         if command_override is None:
             command_override = command
@@ -1310,7 +1310,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         elif self.dev_type == DEV_TYPE_0D and command == DP_QUERY:
             json_data[PROPERTY_DPS] = self.dps_to_request
 
-        payload = json.dumps(json_data).replace(" ", "").encode("utf-8")
         if json_data == "":
             payload = ""
         else:


### PR DESCRIPTION
Reverted Heartbeat logic (there seems to be an issue with the HB and negotiating the 3.4 session key) and fixed PAYLOAD_DICT. Now 3.4 devices devices appear to be working, did not have 3.4 gateway to test sub-devices.
#40 
