### PR TITLE
3.7.0 Fix PAYLOAD_DICT and revert Heartbeat logic to upstream

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -182,7 +182,8 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
             status = await self._interface.status()
             if status is None:
                 raise Exception("Failed to retrieve status")
-
+            
+            self._interface.start_heartbeat()
             self.status_updated(status)
 
             if self._disconnect_task is not None:
@@ -340,6 +341,7 @@ class TuyaGatewayDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 is_gateway=True,
             )
 
+            self._interface.start_heartbeat()
             # Re-add and get status of previously added sub-devices
             # Note this assumes the gateway device has not been tear down
             for subitem in self._sub_devices.items():

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -261,12 +261,24 @@ PAYLOAD_DICT = {
             COMMAND_OVERRIDE: CONTROL_NEW,  # Uses CONTROL_NEW command
             COMMAND: {"protocol": 5, "t": "int", "data": ""},
         },
-        DP_QUERY: {COMMAND_OVERRIDE: DP_QUERY_NEW},
+        DP_QUERY: {
+            COMMAND_OVERRIDE: DP_QUERY_NEW,
+            COMMAND: {PARAMETER_GW_ID: "", PARAMETER_DEV_ID: "", PARAMETER_UID: "" },
+        },
         DP_QUERY_NEW: {
-            COMMAND: {PARAMETER_CID: ""},
+            COMMAND: {PARAMETER_DEV_ID: "", PARAMETER_UID: "", PARAMETER_T: ""}
         },
         HEART_BEAT: {
-            COMMAND: {}
+            COMMAND: {PARAMETER_GW_ID: "", PARAMETER_DEV_ID: ""}
+        },
+        CONTROL_NEW: {
+            COMMAND: {PARAMETER_DEV_ID: "", PARAMETER_UID: "", PARAMETER_T: "", PARAMETER_CID: ""}
+        },
+        STATUS: {  # Get Status from Device
+           COMMAND: {PARAMETER_GW_ID: "", PARAMETER_DEV_ID: ""},
+        },
+        UPDATEDPS: {
+            COMMAND: {PARAMETER_DP_ID: [18, 19, 20]},
         },
     },
 }

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -690,6 +690,11 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
     def connection_made(self, transport):
         """Did connect to the device."""
+        self.transport = transport
+        self.on_connected.set_result(True)
+
+    def start_heartbeat(self):
+        """Start the heartbeat transmissions with the device."""
 
         async def heartbeat_loop():
             """Continuously send heart beat updates."""
@@ -712,8 +717,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             self.transport = None
             transport.close()
 
-        self.transport = transport
-        self.on_connected.set_result(True)
         self.heartbeater = self.loop.create_task(heartbeat_loop())
 
     def data_received(self, data):

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -1238,11 +1238,11 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
         json_data = command_override = None
         if self.dev_type in payload_dict and command in payload_dict[self.dev_type]:
-            if command in payload_dict[self.dev_type]:
-                json_data = payload_dict[self.dev_type][command]
-            if command_override in payload_dict[self.dev_type][command]:
+            if COMMAND in payload_dict[self.dev_type][command]:
+                json_data = payload_dict[self.dev_type][command][COMMAND]
+            if COMMAND_OVERRIDE in payload_dict[self.dev_type][command]:
                 command_override = payload_dict[self.dev_type][command][
-                    command_override
+                    COMMAND_OVERRIDE
                 ]
 
         if self.dev_type != DEV_TYPE_0A:
@@ -1250,16 +1250,16 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 json_data is None
                 and self.dev_type in payload_dict
                 and command in payload_dict[self.dev_type]
-                and command in payload_dict[self.dev_type][command]
+                and COMMAND in payload_dict[self.dev_type][command]
             ):
-                json_data = payload_dict[self.dev_type][command][command]
+                json_data = payload_dict[self.dev_type][command][COMMAND]
             if (
                 command_override is None
                 and self.dev_type in payload_dict
                 and command in payload_dict[self.dev_type]
-                and command_override in payload_dict[self.dev_type][command]
+                and COMMAND_OVERRIDE in payload_dict[self.dev_type][command]
             ):
-                command_override = payload_dict[self.dev_type][command][command_override]
+                command_override = payload_dict[self.dev_type][command][COMMAND_OVERRIDE]
 
         if command_override is None:
             command_override = command
@@ -1310,7 +1310,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         elif self.dev_type == DEV_TYPE_0D and command == DP_QUERY:
             json_data[PROPERTY_DPS] = self.dps_to_request
 
-        payload = json.dumps(json_data).replace(" ", "").encode("utf-8")
         if json_data == "":
             payload = ""
         else:


### PR DESCRIPTION
* fixed PAYLOAD_DICT for v34 devices (only tested and likely working just for devices not sub-devices)
* reverted Heartbeat logic to upstream (heartbeat is started after initial status retrieval - another reason why 3.4 gateways might not work properly)
#40
#35 